### PR TITLE
fix relative imports

### DIFF
--- a/src/applyInputOptions.ts
+++ b/src/applyInputOptions.ts
@@ -1,5 +1,5 @@
-import { IEncodeOptions, IBasisEncoder } from "./type";
-import { DefaultOptions } from "./utils";
+import { IEncodeOptions, IBasisEncoder } from "./type.js";
+import { DefaultOptions } from "./utils.js";
 
 export function applyInputOptions(options: Partial<IEncodeOptions> = {}, encoder: IBasisEncoder) {
   options = { ...DefaultOptions, ...options };


### PR DESCRIPTION
This PR fixes an import path issue that affects ESM projects.
In ESM environments, relative imports must include the file extension (e.g., ./utils.js).
A missing .js extension in one import caused runtime errors when used in Node.js projects.
This change adds the missing extension to ensure compatibility with ESM modules.