### PR TITLE
fix: release BasisEncoder WASM allocation per encode call (#31)

### DIFF
--- a/src/node/NodeBasisEncoder.ts
+++ b/src/node/NodeBasisEncoder.ts
@@ -19,39 +19,46 @@ class NodeBasisEncoder {
   async encode(bufferOrBufferArray: Uint8Array | CubeBufferData, options: Partial<IEncodeOptions> = {}) {
     const basis = await this.init();
     const encoder = new basis.BasisEncoder();
+    try {
+      const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
+      applyInputOptions(options, encoder);
 
-    const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
-    applyInputOptions(options, encoder);
-
-    for (let i = 0; i < bufferArray.length; i++) {
-      const buffer = bufferArray[i];
-      if (options.isHDR) {
-        encoder.setSliceSourceImageHDR(
-          i,
-          buffer,
-          0,
-          0,
-          options.imageType === "hdr" ? HDRSourceType.HDR : HDRSourceType.EXR,
-          true
-        );
-      } else {
-        const imageData = await options.imageDecoder!(buffer);
-        encoder.setSliceSourceImage(
-          i,
-          new Uint8Array(imageData.data),
-          imageData.width,
-          imageData.height,
-          SourceType.RAW
-        );
+      for (let i = 0; i < bufferArray.length; i++) {
+        const buffer = bufferArray[i];
+        if (options.isHDR) {
+          encoder.setSliceSourceImageHDR(
+            i,
+            buffer,
+            0,
+            0,
+            options.imageType === "hdr" ? HDRSourceType.HDR : HDRSourceType.EXR,
+            true
+          );
+        } else {
+          const imageData = await options.imageDecoder!(buffer);
+          encoder.setSliceSourceImage(
+            i,
+            new Uint8Array(imageData.data),
+            imageData.width,
+            imageData.height,
+            SourceType.RAW
+          );
+        }
       }
-    }
 
-    const resultData = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
-    const resultSize = encoder.encode(resultData);
-    if (resultSize === 0) {
-      throw new Error("Encode failed");
+      const resultData = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
+      const resultSize = encoder.encode(resultData);
+      if (resultSize === 0) {
+        throw new Error("Encode failed");
+      }
+      return Buffer.from(resultData.subarray(0, resultSize));
+    } finally {
+      // Free the WASM-allocated encoder. Without this, every encode call leaks
+      // the encoder struct in the WASM heap, eventually exhausting it and
+      // causing `new BasisEncoder()` itself to throw "Out of bounds memory access"
+      // after ~65 calls in long-running processes (batch tools, workers).
+      encoder.delete();
     }
-    return Buffer.from(resultData.subarray(0, resultSize));
   }
 }
 

--- a/src/web/BrowserBasisEncoder.ts
+++ b/src/web/BrowserBasisEncoder.ts
@@ -52,51 +52,59 @@ class BrowserBasisEncoder {
   ): Promise<Uint8Array> {
     const basisModule = await this.init(options);
     const encoder = new basisModule.BasisEncoder();
-    applyInputOptions(options, encoder);
-    const isCube = Array.isArray(bufferOrBufferArray) && bufferOrBufferArray.length === 6;
-    encoder.setTexType(
-      isCube ? BasisTextureType.cBASISTexTypeCubemapArray : BasisTextureType.cBASISTexType2D
-    );
+    try {
+      applyInputOptions(options, encoder);
+      const isCube = Array.isArray(bufferOrBufferArray) && bufferOrBufferArray.length === 6;
+      encoder.setTexType(
+        isCube ? BasisTextureType.cBASISTexTypeCubemapArray : BasisTextureType.cBASISTexType2D
+      );
 
-    const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
+      const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
 
-    for (let i = 0; i < bufferArray.length; i++) {
-      const buffer = bufferArray[i];
-      if (options.isHDR) {
-        encoder.setSliceSourceImageHDR(
-          i,
-          buffer,
-          0,
-          0,
-          options.imageType === "hdr" ? HDRSourceType.HDR : HDRSourceType.EXR,
-          true
-        );
-      } else {
-        const imageData = await options.imageDecoder!(buffer);
-        encoder.setSliceSourceImage(
-          i,
-          new Uint8Array(imageData.data),
-          imageData.width,
-          imageData.height,
-          SourceType.RAW
-        );
+      for (let i = 0; i < bufferArray.length; i++) {
+        const buffer = bufferArray[i];
+        if (options.isHDR) {
+          encoder.setSliceSourceImageHDR(
+            i,
+            buffer,
+            0,
+            0,
+            options.imageType === "hdr" ? HDRSourceType.HDR : HDRSourceType.EXR,
+            true
+          );
+        } else {
+          const imageData = await options.imageDecoder!(buffer);
+          encoder.setSliceSourceImage(
+            i,
+            new Uint8Array(imageData.data),
+            imageData.width,
+            imageData.height,
+            SourceType.RAW
+          );
+        }
       }
-    }
 
-    const ktx2FileData = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
-    const byteLength = encoder.encode(ktx2FileData);
-    if (byteLength === 0) {
-      throw new Error("Encode failed");
-    }
-    let actualKTX2FileData = new Uint8Array(ktx2FileData.buffer, 0, byteLength);
-    if (options.kvData) {
-      const container = read(ktx2FileData);
-      for (let k in options.kvData) {
-        container.keyValue[k] = options.kvData[k];
+      const ktx2FileData = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
+      const byteLength = encoder.encode(ktx2FileData);
+      if (byteLength === 0) {
+        throw new Error("Encode failed");
       }
-      actualKTX2FileData = write(container, { keepWriter: true });
+      let actualKTX2FileData = new Uint8Array(ktx2FileData.buffer, 0, byteLength);
+      if (options.kvData) {
+        const container = read(ktx2FileData);
+        for (let k in options.kvData) {
+          container.keyValue[k] = options.kvData[k];
+        }
+        actualKTX2FileData = write(container, { keepWriter: true });
+      }
+      return actualKTX2FileData;
+    } finally {
+      // Free the WASM-allocated encoder. Without this, every encode call leaks
+      // the encoder struct in the WASM heap, eventually exhausting it and
+      // causing `new BasisEncoder()` itself to throw "Out of bounds memory access"
+      // after ~65 calls in long-running processes (batch tools, workers).
+      encoder.delete();
     }
-    return actualKTX2FileData;
   }
 }
 


### PR DESCRIPTION
Closes #31

## Summary

`NodeBasisEncoder.encode()` and `BrowserBasisEncoder.encode()` construct `new BasisEncoder()` on every call but never call `.delete()` on it. Emscripten-bound C++ classes hold their state in the WASM heap and require manual `.delete()` to free — JS GC has no visibility into WASM memory, so this leaks per call.

After ~65 calls the WASM heap is fragmented enough that even `new BasisEncoder()` itself faults inside its constructor with:

```
RuntimeError: Out of bounds memory access (evaluating 'invoker(fn)')
```

Single-shot CLI/serverless usage masks the bug (each invocation gets a fresh WASM heap), but anything calling `encode()` many times in one process — backfill scripts, batch tooling, long-running workers — hits the wall.

## Reproduction

Loop `encodeToKTX2` (or `browserEncoder.encode`) on the same image buffer repeatedly. RSS climbs ~70 MB per call against my real glTF source. After ~65 calls on a memory-constrained host, the next encoder construction throws OOB. Confirmed against `0.5.1`.

## Fix

Wrap the encode body in `try`/`finally` and call `encoder.delete()` in the `finally` block on both encoders. The returned buffer is constructed before `finally` runs, and the returned bytes are JS-owned (`Buffer.from(...)` for Node, a `Uint8Array` view for web), so `delete()` is safe at that point.

## Verification

- `npm run test:node` — passes (2/2)
- Vendored the same change in our backfill tool against ktx2-encoder@0.5.1 and saw the leak go away (RSS plateaued instead of monotonically climbing) and processes that previously crashed at iteration ~65 now complete cleanly.

## Notes

I verified `encoder.delete` is exposed by Emscripten on the `BasisEncoder` instance (`typeof e.delete === 'function'`).

Happy to adjust style or split into two PRs if preferred.