### PR TITLE
chore: upgrade pnpm to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "ktx2-encoder",
   "description": "KTX2(.ktx2) encoder for browser applications",
   "type": "module",
-  "packageManager": "pnpm@8.15.9",
+  "packageManager": "pnpm@10.34.5",
   "exports": {
     ".": {
       "node": {
@@ -80,5 +80,11 @@
   },
   "dependencies": {
     "ktx-parse": "^0.7.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
- Bump `packageManager` to `pnpm@10.34.5` to match the existing v9 lockfile format (fixes broken `pnpm outdated` under pnpm 8) and satisfy typedoc 0.28's `pnpm >= 10` requirement.
- Allowlist `esbuild` and `sharp` build scripts via `pnpm.onlyBuiltDependencies`, required since pnpm 10 skips dependency install scripts by default.

Verified: `pnpm install`, `pnpm build` and `pnpm test:node` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)