### PR TITLE
chore: add Oxlint quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Check formatting
+        run: pnpm format:check
+      - name: Build
+        run: pnpm build

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn", "oxc", "vitest", "vue"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "perf": "warn"
+  },
+  "rules": {
+    "no-await-in-loop": "off",
+    "no-underscore-dangle": ["warn", { "allow": ["__KTX2_DEBUG__"] }],
+    "typescript/no-unnecessary-boolean-literal-compare": "off",
+    "typescript/no-unnecessary-type-assertion": "off",
+    "typescript/no-useless-default-assignment": "off"
+  },
+  "env": {
+    "builtin": true,
+    "browser": true,
+    "node": true
+  },
+  "ignorePatterns": [
+    "src/basis/**",
+    "website/public/basis/**",
+    "website/.vitepress/.temp/**",
+    "website/.vitepress/dist/**"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "scripts": {
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
+    "lint": "oxlint --type-aware --deny-warnings .",
+    "lint:fix": "oxlint --type-aware --fix --deny-warnings .",
     "watch": "tsc -p tsconfig.json --watch",
     "build": "tsc -p tsconfig.json && cp -R src/basis dist",
     "test": "npm run test:node && npm run test:web",
@@ -65,6 +67,8 @@
     "bumpp": "^11.1.0",
     "naive-ui": "^2.41.0",
     "oxfmt": "^0.59.0",
+    "oxlint": "^1.74.0",
+    "oxlint-tsgolint": "^0.25.0",
     "playwright": "^1.61.1",
     "sharp": "^0.35.3",
     "three": "^0.172.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,12 @@ importers:
       oxfmt:
         specifier: ^0.59.0
         version: 0.59.0
+      oxlint:
+        specifier: ^1.74.0
+        version: 1.74.0(oxlint-tsgolint@0.25.0)
+      oxlint-tsgolint:
+        specifier: ^0.25.0
+        version: 0.25.0
       playwright:
         specifier: ^1.61.1
         version: 1.61.1
@@ -721,6 +727,158 @@ packages:
 
   '@oxfmt/binding-win32-x64-msvc@0.59.0':
     resolution: {integrity: sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@0.25.0':
+    resolution: {integrity: sha512-87opKlwFP8qS9WHAeETV+kA0fC9Oyj4sg7OxWdI4xQY0WC7zlN6BgG66uE5mvtN5mahkt/gL0i/AVEnX6POq2Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.25.0':
+    resolution: {integrity: sha512-HJmuZexsrhqp4WmETn+Soq7Ogt5F0jirv+cYRSniIPe+d/x5beQzLX69xOLhQRE+8FLGETe7FahWMVP8x0dW4g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.25.0':
+    resolution: {integrity: sha512-aNyYsPREvCJi3qjfBA0sQB7DhT3y/W5Ac2JI2D8IJynoTOAhVZj401Si6901oDajlBWyqJqqojudn0VgHB6+7A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.25.0':
+    resolution: {integrity: sha512-+60+VjK9Mch3uA5WlTdNHuAm5+WA7wPPjuWdPWlU0F6JJpYpGZXUpO1RPKuFEWsBpNbLcLeJ0LbCJ1doWu58NA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.25.0':
+    resolution: {integrity: sha512-r53TO+eHp/t53nnUkQJfrYYXODPAxmtf3RUFQG5XsE2hD21IunliOaAdZXP2UwzCx+r/fbNaEelqTaAHcDr57w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.25.0':
+    resolution: {integrity: sha512-vqe66B+gL9HarhyHemdlfC2VWT7eoA+o/ufZ7zT6AGHv64boyDZIJS3U+rpZo+ey4O7wZtiS/vYR2fWqDoFeBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.74.0':
+    resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.74.0':
+    resolution: {integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.74.0':
+    resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.74.0':
+    resolution: {integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.74.0':
+    resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+    resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+    resolution: {integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+    resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
+    resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+    resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+    resolution: {integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+    resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+    resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
+    resolution: {integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.74.0':
+    resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.74.0':
+    resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+    resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+    resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
+    resolution: {integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2176,6 +2334,23 @@ packages:
       vite-plus:
         optional: true
 
+  oxlint-tsgolint@0.25.0:
+    resolution: {integrity: sha512-7DBpqyLZCfyoXiivyfzt9Xmju/K1RcN+Y1W7buEwrgRCWWF11v9alypPqWGZBmh2erDkKL/kVyhKUH2Px+t13A==}
+    hasBin: true
+
+  oxlint@1.74.0:
+    resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.24.0'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   pac-proxy-agent@7.1.0:
     resolution: {integrity: sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==}
     engines: {node: '>= 14'}
@@ -3422,6 +3597,81 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.59.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@0.25.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.25.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.25.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.25.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.25.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.25.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.74.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.74.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.74.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -4991,6 +5241,38 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.59.0
       '@oxfmt/binding-win32-ia32-msvc': 0.59.0
       '@oxfmt/binding-win32-x64-msvc': 0.59.0
+
+  oxlint-tsgolint@0.25.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.25.0
+      '@oxlint-tsgolint/darwin-x64': 0.25.0
+      '@oxlint-tsgolint/linux-arm64': 0.25.0
+      '@oxlint-tsgolint/linux-x64': 0.25.0
+      '@oxlint-tsgolint/win32-arm64': 0.25.0
+      '@oxlint-tsgolint/win32-x64': 0.25.0
+
+  oxlint@1.74.0(oxlint-tsgolint@0.25.0):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.74.0
+      '@oxlint/binding-android-arm64': 1.74.0
+      '@oxlint/binding-darwin-arm64': 1.74.0
+      '@oxlint/binding-darwin-x64': 1.74.0
+      '@oxlint/binding-freebsd-x64': 1.74.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.74.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.74.0
+      '@oxlint/binding-linux-arm64-gnu': 1.74.0
+      '@oxlint/binding-linux-arm64-musl': 1.74.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-musl': 1.74.0
+      '@oxlint/binding-linux-s390x-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-musl': 1.74.0
+      '@oxlint/binding-openharmony-arm64': 1.74.0
+      '@oxlint/binding-win32-arm64-msvc': 1.74.0
+      '@oxlint/binding-win32-ia32-msvc': 1.74.0
+      '@oxlint/binding-win32-x64-msvc': 1.74.0
+      oxlint-tsgolint: 0.25.0
 
   pac-proxy-agent@7.1.0:
     dependencies:

--- a/src/applyInputOptions.ts
+++ b/src/applyInputOptions.ts
@@ -4,27 +4,28 @@ import { DefaultOptions } from "./utils.js";
 export function applyInputOptions(options: Partial<IEncodeOptions> = {}, encoder: IBasisEncoder) {
   options = { ...DefaultOptions, ...options };
   // basic
-  options.enableDebug !== undefined && encoder.setDebug(options.enableDebug);
-  options.isUASTC !== undefined && encoder.setUASTC(options.isUASTC);
-  options.isKTX2File !== undefined && encoder.setCreateKTX2File(options.isKTX2File);
+  if (options.enableDebug !== undefined) encoder.setDebug(options.enableDebug);
+  if (options.isUASTC !== undefined) encoder.setUASTC(options.isUASTC);
+  if (options.isKTX2File !== undefined) encoder.setCreateKTX2File(options.isKTX2File);
   // extra
-  options.isSetKTX2SRGBTransferFunc !== undefined && encoder.setKTX2SRGBTransferFunc(options.isSetKTX2SRGBTransferFunc);
-  options.generateMipmap !== undefined && encoder.setMipGen(options.generateMipmap);
-  options.isYFlip !== undefined && encoder.setYFlip(options.isYFlip);
-  options.isNormalMap === true && encoder.setNormalMap();
+  if (options.isSetKTX2SRGBTransferFunc !== undefined)
+    encoder.setKTX2SRGBTransferFunc(options.isSetKTX2SRGBTransferFunc);
+  if (options.generateMipmap !== undefined) encoder.setMipGen(options.generateMipmap);
+  if (options.isYFlip !== undefined) encoder.setYFlip(options.isYFlip);
+  if (options.isNormalMap) encoder.setNormalMap();
   // etc1s
-  options.qualityLevel !== undefined && encoder.setQualityLevel(options.qualityLevel);
-  options.compressionLevel !== undefined && encoder.setCompressionLevel(options.compressionLevel);
+  if (options.qualityLevel !== undefined) encoder.setQualityLevel(options.qualityLevel);
+  if (options.compressionLevel !== undefined) encoder.setCompressionLevel(options.compressionLevel);
   // uastc
-  options.needSupercompression !== undefined && encoder.setKTX2UASTCSupercompression(options.needSupercompression);
-  options.enableRDO && encoder.setRDOUASTC(true);
-  options.rdoQualityLevel !== undefined && encoder.setRDOUASTCQualityScalar(options.rdoQualityLevel);
-  options.uastcLDRQualityLevel !== undefined && encoder.setPackUASTCFlags(options.uastcLDRQualityLevel);
+  if (options.needSupercompression !== undefined) encoder.setKTX2UASTCSupercompression(options.needSupercompression);
+  if (options.enableRDO) encoder.setRDOUASTC(true);
+  if (options.rdoQualityLevel !== undefined) encoder.setRDOUASTCQualityScalar(options.rdoQualityLevel);
+  if (options.uastcLDRQualityLevel !== undefined) encoder.setPackUASTCFlags(options.uastcLDRQualityLevel);
   // hdr, only set HDR, if hdr is true, otherwise the format mode will be etc1s
   /** see {@link https://github.com/BinomialLLC/basis_universal/blob/1172d07395a890c782c4f2ef09d2f08606c3f743/webgl/transcoder/basis_wrappers.cpp#L2307-L2321} */
   if (options.isHDR) {
     encoder.setHDR(options.isHDR);
-    options.hdrQualityLevel && encoder.setUASTCHDRQualityLevel(options.hdrQualityLevel);
+    if (options.hdrQualityLevel) encoder.setUASTCHDRQualityLevel(options.hdrQualityLevel);
   }
-  options.isPerceptual !== undefined && encoder.setPerceptual(options.isPerceptual);
+  if (options.isPerceptual !== undefined) encoder.setPerceptual(options.isPerceptual);
 }

--- a/src/gltf-transform/ktx2.ts
+++ b/src/gltf-transform/ktx2.ts
@@ -3,10 +3,10 @@ import { KHRTextureBasisu } from "@gltf-transform/extensions";
 import { IEncodeOptions } from "../type.js";
 
 const NAME = "ktx2";
-const SUPPORTED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const SUPPORTED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 
 function listTextureSlots(texture: Texture): string[] {
-  const document = Document.fromGraph(texture.getGraph())!;
+  const document = Document.fromGraph(texture.getGraph());
   const root = document.getRoot();
   const slots = texture
     .getGraph()
@@ -60,7 +60,7 @@ export function ktx2(options: Partial<KTX2Options> = {}): Transform {
         }
 
         // Skip unsupported mime types
-        if (!SUPPORTED_MIME_TYPES.includes(texture.getMimeType())) {
+        if (!SUPPORTED_MIME_TYPES.has(texture.getMimeType())) {
           logger.debug(`${prefix}: Skipping, unsupported texture type "${texture.getMimeType()}"`);
           return;
         }

--- a/src/node/NodeBasisEncoder.ts
+++ b/src/node/NodeBasisEncoder.ts
@@ -13,7 +13,7 @@ class NodeBasisEncoder {
         return basis;
       });
     }
-    return promise as Promise<IBasisModule>;
+    return promise;
   }
 
   async encode(bufferOrBufferArray: Uint8Array | CubeBufferData, options: Partial<IEncodeOptions> = {}) {
@@ -35,7 +35,8 @@ class NodeBasisEncoder {
             true
           );
         } else {
-          const imageData = await options.imageDecoder!(buffer);
+          if (!options.imageDecoder) throw new Error("imageDecoder is required for non-HDR images");
+          const imageData = await options.imageDecoder(buffer);
           encoder.setSliceSourceImage(
             i,
             new Uint8Array(imageData.data),

--- a/src/type.ts
+++ b/src/type.ts
@@ -158,12 +158,10 @@ export interface IBasisEncoder {
     type: HDRSourceType,
     ldrSrgbToLinear: boolean
   ): void;
-
-  new (): IBasisEncoder;
 }
 
 export interface IBasisModule {
-  BasisEncoder: IBasisEncoder;
+  BasisEncoder: new () => IBasisEncoder;
   initializeBasis: () => void;
 }
 

--- a/src/web/BrowserBasisEncoder.ts
+++ b/src/web/BrowserBasisEncoder.ts
@@ -11,7 +11,7 @@ const DEFAULT_WASM_URL =
 class BrowserBasisEncoder {
   async init(options?: { jsUrl?: string; wasmUrl?: string }) {
     if (!promise) {
-      function _init(): Promise<IBasisModule> {
+      function initModule(): Promise<IBasisModule> {
         const wasmUrl = options?.wasmUrl ?? DEFAULT_WASM_URL;
         const jsUrl = options?.jsUrl ?? "../basis/basis_encoder.js";
         return new Promise((resolve, reject) => {
@@ -28,7 +28,7 @@ class BrowserBasisEncoder {
             .catch(reject);
         });
       }
-      promise = _init();
+      promise = initModule();
     }
     return promise;
   }
@@ -71,7 +71,8 @@ class BrowserBasisEncoder {
             true
           );
         } else {
-          const imageData = await options.imageDecoder!(buffer);
+          if (!options.imageDecoder) throw new Error("imageDecoder is required for non-HDR images");
+          const imageData = await options.imageDecoder(buffer);
           encoder.setSliceSourceImage(
             i,
             new Uint8Array(imageData.data),

--- a/src/web/decodeImageData.ts
+++ b/src/web/decodeImageData.ts
@@ -4,9 +4,11 @@ export const decodeImageBitmap = (function () {
     return function () {
       if (!gl) {
         const canvas = new OffscreenCanvas(128, 128);
-        gl = canvas.getContext("webgl2", { premultipliedAlpha: false });
+        const context = canvas.getContext("webgl2", { premultipliedAlpha: false });
+        if (!context) throw new Error("WebGL2 is not supported");
+        gl = context;
       }
-      return gl as WebGL2RenderingContext;
+      return gl;
     };
   })();
 

--- a/test/gltf-transform.node.test.ts
+++ b/test/gltf-transform.node.test.ts
@@ -8,10 +8,11 @@ async function imageDecoder(buffer: Uint8Array) {
   const image = sharp(buffer);
   const metadata = await image.metadata();
   const { width, height } = metadata;
+  if (!width || !height) throw new Error("Unable to read image dimensions");
   const rawBuffer = await image.ensureAlpha().raw().toBuffer();
   const data = new Uint8Array(rawBuffer);
 
-  return { width: width!, height: height!, data };
+  return { width, height, data };
 }
 
 describe("ktx2 transform node", () => {

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -7,13 +7,14 @@ async function imageDecoder(buffer: Uint8Array) {
   const image = sharp(buffer);
   const metadata = await image.metadata();
   const { width, height } = metadata;
+  if (!width || !height) throw new Error("Unable to read image dimensions");
   const rawBuffer = await image.ensureAlpha().raw().toBuffer();
   const data = new Uint8Array(rawBuffer);
 
   // 创建 imageData 对象
   const imageData = {
-    width: width!,
-    height: height!,
+    width,
+    height,
     data
   };
 

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -37,7 +37,15 @@ test("textureCube", async () => {
     fetch("/tests/cubemap/posz.jpg").then((res) => res.arrayBuffer()),
     fetch("/tests/cubemap/negz.jpg").then((res) => res.arrayBuffer())
   ]).then(async (buffers) => {
-    const result = await encodeToKTX2(buffers.map((buffer) => new Uint8Array(buffer)) as CubeBufferData, {
+    const cubeData: CubeBufferData = [
+      new Uint8Array(buffers[0]),
+      new Uint8Array(buffers[1]),
+      new Uint8Array(buffers[2]),
+      new Uint8Array(buffers[3]),
+      new Uint8Array(buffers[4]),
+      new Uint8Array(buffers[5])
+    ];
+    const result = await encodeToKTX2(cubeData, {
       isUASTC: false,
       enableDebug: false,
       qualityLevel: 230,

--- a/website/.vitepress/components/ktx-encoder.vue
+++ b/website/.vitepress/components/ktx-encoder.vue
@@ -209,7 +209,6 @@ export default defineComponent({
           loading.value = true;
           error.value = "";
 
-          imageFile.value;
           const arrayBuffer = await imageFile.value.arrayBuffer();
           let encodeOptions: IEncodeOptions = {};
           const userOptions = options.value;

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -57,10 +57,11 @@ export default defineConfig({
   },
   transformHtml(code, id) {
     const html = id.split("/").pop();
-    if (!html) return;
+    if (!html) return code;
     const style = fileAndStyles[`/${html}`];
     if (style) {
       return code.replace(/<\/head>/, `${style}</head>`);
     }
+    return code;
   }
 });


### PR DESCRIPTION
## Summary

- add Oxlint with the type-aware `oxlint-tsgolint` backend
- enable correctness, suspicious, performance, TypeScript, Vitest, and Vue rules
- treat warnings as failures and provide `lint` / `lint:fix` scripts
- ignore generated Basis files and VitePress build output
- add a pull-request CI quality gate for frozen install, lint, formatting, and TypeScript build
- resolve the actionable findings from the initial strict lint run

## Why

The project previously had formatting and compiler checks but no dedicated static-analysis layer. Oxlint adds fast correctness and quality checks, while type-aware rules catch problems that syntax-only linting cannot see. Running the checks in pull requests prevents regressions instead of relying on contributors to invoke them manually.

The initial scan found several real issues: side effects expressed as unused boolean expressions, incorrect constructor typing for the Basis module, unchecked image dimensions and WebGL2 context creation, a redundant Vue expression, and less efficient MIME-type membership checks. Rules that require `strictNullChecks` or conflict with intentionally sequential encoder loops are explicitly disabled to avoid false positives.

## Impact

Contributors can run `pnpm lint` and `pnpm lint:fix`. Pull requests must now pass lint, formatting, and build checks. Public APIs and encoder behavior remain unchanged, apart from clearer runtime errors when required decoders, image dimensions, or WebGL2 support are unavailable.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint` (zero warnings and errors)
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (2 Node and 3 Playwright Chromium tests passed)
- `pnpm test:gltf` (2 Node and 2 Playwright Chromium tests passed)
- `pnpm docs:build`
