### PR TITLE
Unify Web and Node encoder core

### DIFF
--- a/src/encodeCore.ts
+++ b/src/encodeCore.ts
@@ -1,0 +1,63 @@
+import { read, write } from "ktx-parse";
+import { applyInputOptions } from "./applyInputOptions.js";
+import { BasisTextureType, HDRSourceType, SourceType } from "./enum.js";
+import { CubeBufferData, IBasisModule, IEncodeOptions } from "./type.js";
+
+export async function encodeWithModule(
+  module: IBasisModule,
+  bufferOrBufferArray: Uint8Array | CubeBufferData,
+  options: Partial<IEncodeOptions> = {}
+): Promise<Uint8Array> {
+  const encoder = new module.BasisEncoder();
+  try {
+    applyInputOptions(options, encoder);
+
+    const isCube = Array.isArray(bufferOrBufferArray) && bufferOrBufferArray.length === 6;
+    encoder.setTexType(isCube ? BasisTextureType.cBASISTexTypeCubemapArray : BasisTextureType.cBASISTexType2D);
+
+    const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
+    for (let i = 0; i < bufferArray.length; i++) {
+      const buffer = bufferArray[i];
+      if (options.isHDR) {
+        encoder.setSliceSourceImageHDR(
+          i,
+          buffer,
+          0,
+          0,
+          options.imageType === "hdr" ? HDRSourceType.HDR : HDRSourceType.EXR,
+          true
+        );
+      } else {
+        if (!options.imageDecoder) throw new Error("imageDecoder is required for non-HDR images");
+        const imageData = await options.imageDecoder(buffer);
+        encoder.setSliceSourceImage(
+          i,
+          new Uint8Array(imageData.data),
+          imageData.width,
+          imageData.height,
+          SourceType.RAW
+        );
+      }
+    }
+
+    const output = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
+    const byteLength = encoder.encode(output);
+    if (byteLength === 0) throw new Error("Encode failed");
+
+    let result: Uint8Array = output.slice(0, byteLength);
+    if (options.kvData) {
+      const container = read(result);
+      for (const key in options.kvData) {
+        container.keyValue[key] = options.kvData[key];
+      }
+      result = write(container, { keepWriter: true });
+    }
+    return result;
+  } finally {
+    // Free the WASM-allocated encoder. Without this, every encode call leaks
+    // the encoder struct in the WASM heap, eventually exhausting it and
+    // causing `new BasisEncoder()` itself to throw "Out of bounds memory access"
+    // after ~65 calls in long-running processes (batch tools, workers).
+    encoder.delete();
+  }
+}

--- a/src/node/NodeBasisEncoder.ts
+++ b/src/node/NodeBasisEncoder.ts
@@ -1,6 +1,5 @@
-import { HDRSourceType, SourceType } from "../enum.js";
 import { CubeBufferData, IBasisModule, IEncodeOptions } from "../type.js";
-import { applyInputOptions } from "../applyInputOptions.js";
+import { encodeWithModule } from "../encodeCore.js";
 import BASIS from "../basis/basis_encoder.js";
 
 let promise: Promise<IBasisModule> | null = null;
@@ -16,50 +15,11 @@ class NodeBasisEncoder {
     return promise;
   }
 
-  async encode(bufferOrBufferArray: Uint8Array | CubeBufferData, options: Partial<IEncodeOptions> = {}) {
-    const basis = await this.init();
-    const encoder = new basis.BasisEncoder();
-    try {
-      const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
-      applyInputOptions(options, encoder);
-
-      for (let i = 0; i < bufferArray.length; i++) {
-        const buffer = bufferArray[i];
-        if (options.isHDR) {
-          encoder.setSliceSourceImageHDR(
-            i,
-            buffer,
-            0,
-            0,
-            options.imageType === "hdr" ? HDRSourceType.HDR : HDRSourceType.EXR,
-            true
-          );
-        } else {
-          if (!options.imageDecoder) throw new Error("imageDecoder is required for non-HDR images");
-          const imageData = await options.imageDecoder(buffer);
-          encoder.setSliceSourceImage(
-            i,
-            new Uint8Array(imageData.data),
-            imageData.width,
-            imageData.height,
-            SourceType.RAW
-          );
-        }
-      }
-
-      const resultData = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
-      const resultSize = encoder.encode(resultData);
-      if (resultSize === 0) {
-        throw new Error("Encode failed");
-      }
-      return Buffer.from(resultData.subarray(0, resultSize));
-    } finally {
-      // Free the WASM-allocated encoder. Without this, every encode call leaks
-      // the encoder struct in the WASM heap, eventually exhausting it and
-      // causing `new BasisEncoder()` itself to throw "Out of bounds memory access"
-      // after ~65 calls in long-running processes (batch tools, workers).
-      encoder.delete();
-    }
+  async encode(
+    bufferOrBufferArray: Uint8Array | CubeBufferData,
+    options: Partial<IEncodeOptions> = {}
+  ): Promise<Uint8Array> {
+    return encodeWithModule(await this.init(), bufferOrBufferArray, options);
   }
 }
 

--- a/src/web/BrowserBasisEncoder.ts
+++ b/src/web/BrowserBasisEncoder.ts
@@ -1,7 +1,5 @@
-import { read, write } from "ktx-parse";
 import { CubeBufferData, IBasisModule, IEncodeOptions } from "../type.js";
-import { applyInputOptions } from "../applyInputOptions.js";
-import { BasisTextureType, HDRSourceType, SourceType } from "../enum.js";
+import { encodeWithModule } from "../encodeCore.js";
 
 let promise: Promise<IBasisModule> | null = null;
 
@@ -50,60 +48,7 @@ class BrowserBasisEncoder {
     bufferOrBufferArray: Uint8Array | CubeBufferData,
     options: Partial<IEncodeOptions> = {}
   ): Promise<Uint8Array> {
-    const basisModule = await this.init(options);
-    const encoder = new basisModule.BasisEncoder();
-    try {
-      applyInputOptions(options, encoder);
-      const isCube = Array.isArray(bufferOrBufferArray) && bufferOrBufferArray.length === 6;
-      encoder.setTexType(isCube ? BasisTextureType.cBASISTexTypeCubemapArray : BasisTextureType.cBASISTexType2D);
-
-      const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
-
-      for (let i = 0; i < bufferArray.length; i++) {
-        const buffer = bufferArray[i];
-        if (options.isHDR) {
-          encoder.setSliceSourceImageHDR(
-            i,
-            buffer,
-            0,
-            0,
-            options.imageType === "hdr" ? HDRSourceType.HDR : HDRSourceType.EXR,
-            true
-          );
-        } else {
-          if (!options.imageDecoder) throw new Error("imageDecoder is required for non-HDR images");
-          const imageData = await options.imageDecoder(buffer);
-          encoder.setSliceSourceImage(
-            i,
-            new Uint8Array(imageData.data),
-            imageData.width,
-            imageData.height,
-            SourceType.RAW
-          );
-        }
-      }
-
-      const ktx2FileData = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
-      const byteLength = encoder.encode(ktx2FileData);
-      if (byteLength === 0) {
-        throw new Error("Encode failed");
-      }
-      let actualKTX2FileData: Uint8Array = ktx2FileData.slice(0, byteLength);
-      if (options.kvData) {
-        const container = read(actualKTX2FileData);
-        for (let k in options.kvData) {
-          container.keyValue[k] = options.kvData[k];
-        }
-        actualKTX2FileData = write(container, { keepWriter: true });
-      }
-      return actualKTX2FileData;
-    } finally {
-      // Free the WASM-allocated encoder. Without this, every encode call leaks
-      // the encoder struct in the WASM heap, eventually exhausting it and
-      // causing `new BasisEncoder()` itself to throw "Out of bounds memory access"
-      // after ~65 calls in long-running processes (batch tools, workers).
-      encoder.delete();
-    }
+    return encodeWithModule(await this.init(options), bufferOrBufferArray, options);
   }
 }
 

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "vitest";
 import { encodeToKTX2 } from "../src/node";
+import { nodeEncoder } from "../src/node/NodeBasisEncoder";
+import { CubeBufferData } from "../src/type";
+import { read } from "ktx-parse";
 import { readFile } from "fs/promises";
 import sharp from "sharp";
 
@@ -51,4 +54,40 @@ test("etc1s", { timeout: Infinity }, async () => {
   const testArray = Array.from(new Uint8Array(resultBuffer));
   const resultArray = Array.from(result);
   expect(testArray).toEqual(resultArray);
+});
+
+test("kvData", { timeout: Infinity }, async () => {
+  const buffer = await readFile("./public/tests/DuckCM.png");
+  const result = await encodeToKTX2(new Uint8Array(buffer), {
+    isUASTC: true,
+    enableDebug: false,
+    qualityLevel: 230,
+    generateMipmap: true,
+    imageDecoder,
+    kvData: { testKey: "testValue" }
+  });
+
+  expect(read(result).keyValue.testKey).toEqual(new TextEncoder().encode("testValue\0"));
+});
+
+test("textureCube", { timeout: Infinity }, async () => {
+  const paths = ["posx", "negx", "posy", "negy", "posz", "negz"];
+  const buffers = await Promise.all(paths.map((path) => readFile(`./public/tests/cubemap/${path}.jpg`)));
+  const cubeData: CubeBufferData = [
+    new Uint8Array(buffers[0]),
+    new Uint8Array(buffers[1]),
+    new Uint8Array(buffers[2]),
+    new Uint8Array(buffers[3]),
+    new Uint8Array(buffers[4]),
+    new Uint8Array(buffers[5])
+  ];
+  const result = await nodeEncoder.encode(cubeData, {
+    isUASTC: false,
+    enableDebug: false,
+    qualityLevel: 230,
+    generateMipmap: false,
+    imageDecoder
+  });
+
+  expect(read(result).faceCount).toBe(6);
 });


### PR DESCRIPTION
## Summary

- move the shared Web and Node encoding pipeline into `encodeWithModule`
- make Node honor `kvData` and cubemap texture types consistently with Web
- add Node regression coverage for metadata round-tripping and six-face cubemaps

## Why

The Web and Node encoders duplicated nearly all encoding logic and had already diverged: Node silently ignored `kvData` and did not set the cubemap texture type. Centralizing input setup, encoding, output handling, metadata writing, and encoder cleanup prevents further platform drift.

## Impact

Node now writes requested key-value metadata, emits six-face cubemaps correctly through the internal encoder, and returns the same plain `Uint8Array` shape as Web. Existing UASTC and ETC1S output remains byte-for-byte compatible with the golden fixtures. Platform-specific classes now only initialize their WASM module and delegate encoding.

## Validation

- `pnpm exec oxfmt --check src/encodeCore.ts src/web/BrowserBasisEncoder.ts src/node/NodeBasisEncoder.ts test/node.test.ts test/web.test.ts`
- `pnpm exec oxlint --type-aware --deny-warnings src/encodeCore.ts src/web/BrowserBasisEncoder.ts src/node/NodeBasisEncoder.ts test/node.test.ts test/web.test.ts`
- `pnpm run build`
- `pnpm run test` (Node 4/4, Web 4/4)
- `pnpm run test:gltf` (Node 2/2, Web 2/2)
