### PR TITLE
Use bundled WASM in browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ await document.transform(
 );
 ```
 
-The browser build loads its bundled `basis_encoder.wasm` by default. To serve a matching WASM file from a custom location or CDN, set `wasmUrl` explicitly. See the [advanced guide](./website/guide/advanced.md#custom-wasm-loading).
+The browser build loads its bundled `basis_encoder.wasm` by default and falls back to the project's CDN copy if the bundled asset cannot be fetched. To serve a matching WASM file from a custom location or CDN, set `wasmUrl` explicitly. See the [advanced guide](./website/guide/advanced.md#custom-wasm-loading).
 
 ## Tool
 

--- a/README.md
+++ b/README.md
@@ -47,13 +47,12 @@ await document.transform(
   ktx2({
     isUASTC: true,
     enableDebug: false,
-    generateMipmap: true,
-    wasmUrl: "/basis_encoder.wasm"
+    generateMipmap: true
   })
 );
 ```
 
-> **Note:** It's recommended to host the `basis_encoder.wasm` file on your own server.
+The browser build loads its bundled `basis_encoder.wasm` by default. To serve a matching WASM file from a custom location or CDN, set `wasmUrl` explicitly. See the [advanced guide](./website/guide/advanced.md#custom-wasm-loading).
 
 ## Tool
 

--- a/src/basis/basis_encoder.d.ts
+++ b/src/basis/basis_encoder.d.ts
@@ -1,4 +1,4 @@
 import type { IBasisModule } from "../../type";
 
-declare const BASIS: () => IBasisModule;
+declare const BASIS: (options?: { wasmBinary?: ArrayBuffer }) => Promise<IBasisModule>;
 export default BASIS;

--- a/src/basis/basis_encoder.js
+++ b/src/basis/basis_encoder.js
@@ -3,7 +3,7 @@
 const ENVIRONMENT_IS_NODE=typeof process=="object"&&typeof process.versions=="object"&&typeof 
 process.versions.node=="string";
 if(ENVIRONMENT_IS_NODE){
-  const { createRequire } = await import('module');
+  const { createRequire } = await import(/* webpackIgnore: true */ /* @vite-ignore */ 'module');
   /** @suppress{duplicate} */
   var require = createRequire(import.meta.url);
   const path = require('node:path');

--- a/src/type.ts
+++ b/src/type.ts
@@ -257,9 +257,7 @@ interface BasisOptions {
    * @returns
    */
   imageDecoder?: (buffer: Uint8Array) => Promise<{ width: number; height: number; data: Uint8Array }>;
-  /**
-   * js url
-   */
+  /** @deprecated The bundled Basis encoder module is always used. */
   jsUrl?: string;
   /**
    * wasm url

--- a/src/web/BrowserBasisEncoder.ts
+++ b/src/web/BrowserBasisEncoder.ts
@@ -5,6 +5,26 @@ import BASIS from "../basis/basis_encoder.js";
 let promise: Promise<IBasisModule> | null = null;
 
 const DEFAULT_WASM_URL = new URL("../basis/basis_encoder.wasm", import.meta.url).href;
+const FALLBACK_WASM_URL =
+  "https://mdn.alipayobjects.com/rms/afts/file/A*r7D4SKbksYcAAAAAAAAAAAAAARQnAQ/basis_encoder.wasm";
+
+async function fetchWasm(wasmUrl: string): Promise<ArrayBuffer> {
+  const response = await fetch(wasmUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch basis_encoder.wasm from ${wasmUrl}: ${response.status}`);
+  }
+  return response.arrayBuffer();
+}
+
+export async function fetchWasmBinary(wasmUrl: string, fallbackUrl?: string): Promise<ArrayBuffer> {
+  try {
+    return await fetchWasm(wasmUrl);
+  } catch (error) {
+    if (!fallbackUrl) throw error;
+    console.warn(`Failed to load bundled basis_encoder.wasm; falling back to ${fallbackUrl}`);
+    return fetchWasm(fallbackUrl);
+  }
+}
 
 class BrowserBasisEncoder {
   async init(options?: { jsUrl?: string; wasmUrl?: string }) {
@@ -14,11 +34,8 @@ class BrowserBasisEncoder {
     if (!promise) {
       async function initModule(): Promise<IBasisModule> {
         const wasmUrl = options?.wasmUrl ?? DEFAULT_WASM_URL;
-        const response = await fetch(wasmUrl);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch basis_encoder.wasm from ${wasmUrl}: ${response.status}`);
-        }
-        const module: IBasisModule = await BASIS({ wasmBinary: await response.arrayBuffer() });
+        const wasmBinary = await fetchWasmBinary(wasmUrl, options?.wasmUrl ? undefined : FALLBACK_WASM_URL);
+        const module: IBasisModule = await BASIS({ wasmBinary });
         module.initializeBasis();
         return module;
       }

--- a/src/web/BrowserBasisEncoder.ts
+++ b/src/web/BrowserBasisEncoder.ts
@@ -1,30 +1,26 @@
 import { CubeBufferData, IBasisModule, IEncodeOptions } from "../type.js";
 import { encodeWithModule } from "../encodeCore.js";
+import BASIS from "../basis/basis_encoder.js";
 
 let promise: Promise<IBasisModule> | null = null;
 
-const DEFAULT_WASM_URL =
-  "https://mdn.alipayobjects.com/rms/afts/file/A*r7D4SKbksYcAAAAAAAAAAAAAARQnAQ/basis_encoder.wasm";
+const DEFAULT_WASM_URL = new URL("../basis/basis_encoder.wasm", import.meta.url).href;
 
 class BrowserBasisEncoder {
   async init(options?: { jsUrl?: string; wasmUrl?: string }) {
+    if (options?.jsUrl) {
+      console.warn("The jsUrl option is deprecated and ignored. The bundled Basis encoder module is always used.");
+    }
     if (!promise) {
-      function initModule(): Promise<IBasisModule> {
+      async function initModule(): Promise<IBasisModule> {
         const wasmUrl = options?.wasmUrl ?? DEFAULT_WASM_URL;
-        const jsUrl = options?.jsUrl ?? "../basis/basis_encoder.js";
-        return new Promise((resolve, reject) => {
-          Promise.all([
-            import(/* @vite-ignore */ jsUrl),
-            wasmUrl ? fetch(wasmUrl).then((res) => res.arrayBuffer()) : undefined
-          ])
-            .then(([{ default: BASIS }, wasmBinary]) => {
-              return BASIS({ wasmBinary }).then((Module: IBasisModule) => {
-                Module.initializeBasis();
-                resolve(Module);
-              });
-            })
-            .catch(reject);
-        });
+        const response = await fetch(wasmUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch basis_encoder.wasm from ${wasmUrl}: ${response.status}`);
+        }
+        const module: IBasisModule = await BASIS({ wasmBinary: await response.arrayBuffer() });
+        module.initializeBasis();
+        return module;
       }
       promise = initModule();
     }

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { read } from "ktx-parse";
 import { CubeBufferData, encodeToKTX2 } from "../src/web";
+import { browserEncoder } from "../src/web/BrowserBasisEncoder";
 
 test("uastc", async () => {
   const buffer = await fetch("/tests/DuckCM.png").then((res) => res.arrayBuffer());
@@ -15,6 +16,18 @@ test("uastc", async () => {
   const resultBuffer = await fetch("/tests/DuckCM-uastc.ktx2").then((res) => res.arrayBuffer());
   expect(result).toEqual(new Uint8Array(resultBuffer));
   expect(result.buffer.byteLength).toBe(result.byteLength);
+});
+
+test("warns when deprecated jsUrl is provided", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  try {
+    await browserEncoder.init({ jsUrl: "/custom-basis-encoder.js" });
+    expect(warn).toHaveBeenCalledWith(
+      "The jsUrl option is deprecated and ignored. The bundled Basis encoder module is always used."
+    );
+  } finally {
+    warn.mockRestore();
+  }
 });
 
 test("kvData", async () => {

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { read } from "ktx-parse";
 import { CubeBufferData, encodeToKTX2 } from "../src/web";
-import { browserEncoder } from "../src/web/BrowserBasisEncoder";
+import { browserEncoder, fetchWasmBinary } from "../src/web/BrowserBasisEncoder";
 
 test("uastc", async () => {
   const buffer = await fetch("/tests/DuckCM.png").then((res) => res.arrayBuffer());
@@ -26,6 +26,23 @@ test("warns when deprecated jsUrl is provided", async () => {
       "The jsUrl option is deprecated and ignored. The bundled Basis encoder module is always used."
     );
   } finally {
+    warn.mockRestore();
+  }
+});
+
+test("falls back to the CDN when the bundled WASM cannot be loaded", async () => {
+  const fetchMock = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(new Response(null, { status: 404 }))
+    .mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3])));
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const fallbackUrl = "https://mdn.alipayobjects.com/rms/afts/file/A*r7D4SKbksYcAAAAAAAAAAAAAARQnAQ/basis_encoder.wasm";
+  try {
+    expect(new Uint8Array(await fetchWasmBinary("/bundled.wasm", fallbackUrl))).toEqual(new Uint8Array([1, 2, 3]));
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/bundled.wasm");
+    expect(fetchMock).toHaveBeenNthCalledWith(2, fallbackUrl);
+  } finally {
+    fetchMock.mockRestore();
     warn.mockRestore();
   }
 });

--- a/website/guide/advanced.md
+++ b/website/guide/advanced.md
@@ -46,7 +46,7 @@ const options = {
 
 ## Custom WASM Loading
 
-Browser builds load the package's version-matched `basis_encoder.wasm` asset by default. No third-party network request or additional configuration is required with modern bundlers such as Vite, Webpack 5, Rollup, and esbuild.
+Browser builds first load the package's version-matched `basis_encoder.wasm` asset. If that request fails, the encoder falls back to the project's CDN-hosted copy. No third-party request is made when the bundled asset is available.
 
 To host the WASM asset yourself or use a CDN, override `wasmUrl`:
 
@@ -57,6 +57,8 @@ const ktx2Data = await encodeToKTX2(imageBuffer, {
 ```
 
 The custom WASM file must come from the same `ktx2-encoder` version as the bundled JavaScript glue. The legacy `jsUrl` option is deprecated and ignored because replacing only the glue can create an incompatible module pair.
+
+When `wasmUrl` is set explicitly, a failed request is reported directly and does not fall back to the default CDN.
 
 ## Node.js Usage
 

--- a/website/guide/advanced.md
+++ b/website/guide/advanced.md
@@ -44,6 +44,20 @@ const options = {
 };
 ```
 
+## Custom WASM Loading
+
+Browser builds load the package's version-matched `basis_encoder.wasm` asset by default. No third-party network request or additional configuration is required with modern bundlers such as Vite, Webpack 5, Rollup, and esbuild.
+
+To host the WASM asset yourself or use a CDN, override `wasmUrl`:
+
+```typescript
+const ktx2Data = await encodeToKTX2(imageBuffer, {
+  wasmUrl: "/assets/basis_encoder.wasm"
+});
+```
+
+The custom WASM file must come from the same `ktx2-encoder` version as the bundled JavaScript glue. The legacy `jsUrl` option is deprecated and ignored because replacing only the glue can create an incompatible module pair.
+
 ## Node.js Usage
 
 When using in Node.js, you need to provide an image decoder:

--- a/website/guide/api.md
+++ b/website/guide/api.md
@@ -51,8 +51,8 @@ Complete configuration options for the encoder:
 | `kvData` | Record<string, string \| Uint8Array> | {} | Custom key-value metadata for the KTX2 file |
 | `type` | SourceType | - | Type of input source (RAW = 0, PNG = 1) |
 | `imageDecoder` | Function | undefined | Function to decode compressed image buffer to RGBA (Required for Node.js) |
-| `jsUrl` | string | undefined | URL to the JavaScript module |
-| `wasmUrl` | string | undefined | URL to the WebAssembly module |
+| `jsUrl` | string | undefined | Deprecated and ignored; the bundled JavaScript module is always used |
+| `wasmUrl` | string | bundled asset | Optional URL overriding the bundled WebAssembly module |
 
 ### Image Decoder Function Type
 


### PR DESCRIPTION
## Summary

- statically import the bundled Basis encoder glue in browser builds
- resolve the matching `basis_encoder.wasm` with `new URL(..., import.meta.url)` instead of a third-party CDN default
- fall back to the existing CDN copy only when the bundled WASM request fails
- preserve custom `wasmUrl` overrides without fallback and deprecate the ignored `jsUrl` option with a runtime warning
- report non-successful WASM fetches with the URL and HTTP status
- document bundled and custom WASM loading behavior
- keep the glue's Node-only `module` import external to Vite and Webpack browser bundles

## Why

The previous browser default fetched WASM from an unrelated third-party CDN and dynamically imported the glue through a runtime string. This created an availability and supply-chain risk and prevented bundlers from reliably analyzing and fingerprinting the package assets.

During Webpack validation, the Emscripten glue's Node-only `import("module")` was also found to be statically resolved by Webpack in browser builds. Bundler-ignore annotations preserve Node behavior while allowing browser consumers to bundle the shared glue.

## Impact

Browser consumers first use a version-matched, locally bundled WASM asset, so the normal path makes no third-party request. If that asset cannot be fetched, the existing CDN URL remains available as a fallback. Existing custom `wasmUrl` deployments continue to work and fail directly instead of silently falling back; `jsUrl` remains in the type surface temporarily but is ignored with a deprecation warning.

## Validation

- formatting and type-aware lint checks
- `pnpm run build`
- `pnpm run test` (Node 4/4, Web 6/6, including CDN fallback coverage)
- `pnpm run test:gltf` (Node 2/2, Web 2/2)
- minimal Webpack 5.108 consumer build emitted `bundle.js` and a content-hashed 1.65 MB `.wasm` asset
