### PR TITLE
Size encoder output buffers dynamically

### DIFF
--- a/src/encodeCore.ts
+++ b/src/encodeCore.ts
@@ -2,6 +2,25 @@ import { read, write } from "ktx-parse";
 import { applyInputOptions } from "./applyInputOptions.js";
 import { BasisTextureType, HDRSourceType, SourceType } from "./enum.js";
 import { CubeBufferData, IBasisModule, IEncodeOptions } from "./type.js";
+import { DefaultOptions } from "./utils.js";
+
+const OUTPUT_HEADER_SLACK = 64 * 1024;
+const DEFAULT_HDR_OUTPUT_CAPACITY = 24 * 1024 * 1024;
+
+export function estimateOutputCapacity(
+  slices: ReadonlyArray<{ width: number; height: number }> | null,
+  inputByteLength: number,
+  isHDR: boolean,
+  generateMipmap: boolean
+): number {
+  if (!isHDR && slices) {
+    const texels = slices.reduce((total, { width, height }) => total + Math.max(0, width) * Math.max(0, height), 0);
+    const mipFactor = generateMipmap ? 4 / 3 : 1;
+    return Math.ceil(texels * 4 * mipFactor) + OUTPUT_HEADER_SLACK;
+  }
+
+  return Math.max(Math.max(0, inputByteLength) * 8, DEFAULT_HDR_OUTPUT_CAPACITY) + OUTPUT_HEADER_SLACK;
+}
 
 export async function encodeWithModule(
   module: IBasisModule,
@@ -16,6 +35,8 @@ export async function encodeWithModule(
     encoder.setTexType(isCube ? BasisTextureType.cBASISTexTypeCubemapArray : BasisTextureType.cBASISTexType2D);
 
     const bufferArray = Array.isArray(bufferOrBufferArray) ? bufferOrBufferArray : [bufferOrBufferArray];
+    const inputByteLength = bufferArray.reduce((total, buffer) => total + buffer.byteLength, 0);
+    const slices: Array<{ width: number; height: number }> = [];
     for (let i = 0; i < bufferArray.length; i++) {
       const buffer = bufferArray[i];
       if (options.isHDR) {
@@ -30,6 +51,7 @@ export async function encodeWithModule(
       } else {
         if (!options.imageDecoder) throw new Error("imageDecoder is required for non-HDR images");
         const imageData = await options.imageDecoder(buffer);
+        slices.push({ width: imageData.width, height: imageData.height });
         encoder.setSliceSourceImage(
           i,
           new Uint8Array(imageData.data),
@@ -40,11 +62,37 @@ export async function encodeWithModule(
       }
     }
 
-    const output = new Uint8Array(1024 * 1024 * (options.isHDR ? 24 : 10));
-    const byteLength = encoder.encode(output);
-    if (byteLength === 0) throw new Error("Encode failed");
+    let capacity =
+      options.outputBufferSize ??
+      estimateOutputCapacity(
+        options.isHDR ? null : slices,
+        inputByteLength,
+        options.isHDR ?? false,
+        options.generateMipmap ?? DefaultOptions.generateMipmap
+      );
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new Error(`outputBufferSize must be a positive safe integer; received ${capacity}`);
+    }
 
-    let result: Uint8Array = output.slice(0, byteLength);
+    let result: Uint8Array | null = null;
+    const attemptedCapacities: number[] = [];
+    for (let attempt = 0; attempt < 2; attempt++) {
+      attemptedCapacities.push(capacity);
+      const output = new Uint8Array(capacity);
+      const byteLength = encoder.encode(output);
+      if (byteLength > 0) {
+        result = output.slice(0, byteLength);
+        break;
+      }
+      capacity *= 2;
+    }
+    if (!result) {
+      throw new Error(
+        `Encode failed after attempts with ${attemptedCapacities.join(" and ")} byte output buffers. ` +
+          "The output may be too large, the input or encoder options may be invalid, or the WASM encoder may have exceeded its resource limits."
+      );
+    }
+
     if (options.kvData) {
       const container = read(result);
       for (const key in options.kvData) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -249,6 +249,12 @@ interface BasisOptions {
   /** kv data */
   kvData?: Record<string, string | Uint8Array>;
 
+  /**
+   * Initial output buffer capacity in bytes. The encoder retries once with twice this capacity if encoding fails.
+   * By default, capacity is estimated from the decoded input dimensions.
+   */
+  outputBufferSize?: number;
+
   /** type */
   type?: SourceType;
   /**

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import { encodeToKTX2 } from "../src/node";
 import { nodeEncoder } from "../src/node/NodeBasisEncoder";
 import { CubeBufferData } from "../src/type";
+import { estimateOutputCapacity } from "../src/encodeCore";
 import { read } from "ktx-parse";
 import { readFile } from "fs/promises";
 import sharp from "sharp";
@@ -26,18 +27,50 @@ async function imageDecoder(buffer: Uint8Array) {
 
 test("uastc", { timeout: Infinity }, async () => {
   const buffer = await readFile("./public/tests/DuckCM.png");
+  const resultBuffer = await readFile("./public/tests/DuckCM-uastc.ktx2");
   const result = await encodeToKTX2(new Uint8Array(buffer), {
     isUASTC: true,
     enableDebug: false,
     qualityLevel: 230,
     generateMipmap: true,
-    imageDecoder
+    imageDecoder,
+    outputBufferSize: Math.ceil(resultBuffer.byteLength / 2)
   });
 
-  const resultBuffer = await readFile("./public/tests/DuckCM-uastc.ktx2");
   const testArray = Array.from(new Uint8Array(resultBuffer));
   const resultArray = Array.from(result);
   expect(testArray).toEqual(resultArray);
+});
+
+test("estimates output buffer capacity", () => {
+  const headerSlack = 64 * 1024;
+
+  expect(estimateOutputCapacity([{ width: 4, height: 4 }], 0, false, false)).toBe(headerSlack + 64);
+  expect(estimateOutputCapacity([{ width: 3, height: 5 }], 0, false, true)).toBe(headerSlack + 80);
+  expect(
+    estimateOutputCapacity(
+      Array.from({ length: 6 }, () => ({ width: 4, height: 4 })),
+      0,
+      false,
+      false
+    )
+  ).toBe(headerSlack + 384);
+  expect(estimateOutputCapacity([{ width: 0, height: 0 }], 0, false, false)).toBe(headerSlack);
+  expect(estimateOutputCapacity(null, 1024, true, true)).toBe(24 * 1024 * 1024 + headerSlack);
+});
+
+test("reports attempted output buffer sizes when encoding fails", { timeout: Infinity }, async () => {
+  const buffer = await readFile("./public/tests/DuckCM.png");
+
+  await expect(
+    encodeToKTX2(new Uint8Array(buffer), {
+      isUASTC: true,
+      imageDecoder,
+      outputBufferSize: 1
+    })
+  ).rejects.toThrow(
+    "Encode failed after attempts with 1 and 2 byte output buffers. The output may be too large, the input or encoder options may be invalid, or the WASM encoder may have exceeded its resource limits."
+  );
 });
 
 test("etc1s", { timeout: Infinity }, async () => {

--- a/website/guide/api.md
+++ b/website/guide/api.md
@@ -49,6 +49,7 @@ Complete configuration options for the encoder:
 | `generateMipmap` | boolean | false | Generate mipmaps from source images |
 | `isKTX2File` | boolean | false | Create .KTX2 files instead of .basis files |
 | `kvData` | Record<string, string \| Uint8Array> | {} | Custom key-value metadata for the KTX2 file |
+| `outputBufferSize` | number | estimated | Initial output buffer capacity in bytes; encoding retries once at twice this size on failure |
 | `type` | SourceType | - | Type of input source (RAW = 0, PNG = 1) |
 | `imageDecoder` | Function | undefined | Function to decode compressed image buffer to RGBA (Required for Node.js) |
 | `jsUrl` | string | undefined | Deprecated and ignored; the bundled JavaScript module is always used |


### PR DESCRIPTION
## Summary

- estimate LDR output capacity from decoded dimensions, slice count, and mipmap settings
- retain a conservative HDR capacity derived from input size with a 24 MiB floor
- retry encoding once with twice the output capacity when the WASM wrapper returns zero
- add an `outputBufferSize` escape hatch and actionable validation/failure messages
- cover non-power-of-two, zero-size, cubemap, HDR, successful retry, and exhausted retry behavior

## Why

The shared encoder always allocated 10 MiB for LDR or 24 MiB for HDR regardless of input size. Small textures paid a large unnecessary allocation cost, while larger outputs could fail with only `Encode failed`.

The Basis WASM wrapper returns zero both when its destination buffer is too small and for unrelated initialization, input, compressor, or resource-limit failures. This change therefore retries only once and keeps the final error deliberately noncommittal while reporting both attempted capacities.

## Impact

Typical small LDR encodes allocate from decoded texture dimensions instead of a fixed 10 MiB buffer. Callers with unusual workloads may set `outputBufferSize`; a zero result triggers one full re-encode at twice the capacity.

The proposal's 4096×4096 WASM acceptance case is intentionally not included because the current 32-bit Basis wrapper has source-texel limits that can reject 16.7M texels before output copying, independently of JavaScript buffer capacity.

## Validation

- formatting and type-aware lint checks
- `pnpm run build`
- `pnpm run test` (Node 6/6, Web 6/6)
- `pnpm run test:gltf` (Node 2/2, Web 2/2)
- real WASM regression: first UASTC attempt uses half the known output size and succeeds after the single doubling retry
- real WASM failure regression: 1-byte and 2-byte attempts produce the diagnostic error
