### PR TITLE
Make encoder initialization retryable

### DIFF
--- a/src/node/NodeBasisEncoder.ts
+++ b/src/node/NodeBasisEncoder.ts
@@ -2,17 +2,17 @@ import { CubeBufferData, IBasisModule, IEncodeOptions } from "../type.js";
 import { encodeWithModule } from "../encodeCore.js";
 import BASIS from "../basis/basis_encoder.js";
 
-let promise: Promise<IBasisModule> | null = null;
+export class NodeBasisEncoder {
+  private modulePromise: Promise<IBasisModule> | null = null;
 
-class NodeBasisEncoder {
   async init(): Promise<IBasisModule> {
-    if (!promise) {
-      promise = BASIS().then((basis: IBasisModule) => {
+    if (!this.modulePromise) {
+      this.modulePromise = BASIS().then((basis: IBasisModule) => {
         basis.initializeBasis();
         return basis;
       });
     }
-    return promise;
+    return this.modulePromise;
   }
 
   async encode(

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,6 +1,8 @@
 import { IEncodeOptions } from "../type.js";
 import { nodeEncoder } from "./NodeBasisEncoder.js";
 
+export { NodeBasisEncoder } from "./NodeBasisEncoder.js";
+
 export function encodeToKTX2(imageBuffer: Uint8Array, options: Partial<IEncodeOptions> = {}): Promise<Uint8Array> {
   if (!options.imageDecoder) {
     throw "imageDecoder is required in Node.js.";

--- a/src/web/BrowserBasisEncoder.ts
+++ b/src/web/BrowserBasisEncoder.ts
@@ -2,8 +2,6 @@ import { CubeBufferData, IBasisModule, IEncodeOptions } from "../type.js";
 import { encodeWithModule } from "../encodeCore.js";
 import BASIS from "../basis/basis_encoder.js";
 
-let promise: Promise<IBasisModule> | null = null;
-
 const DEFAULT_WASM_URL = new URL("../basis/basis_encoder.wasm", import.meta.url).href;
 const FALLBACK_WASM_URL =
   "https://mdn.alipayobjects.com/rms/afts/file/A*r7D4SKbksYcAAAAAAAAAAAAAARQnAQ/basis_encoder.wasm";
@@ -26,22 +24,39 @@ export async function fetchWasmBinary(wasmUrl: string, fallbackUrl?: string): Pr
   }
 }
 
-class BrowserBasisEncoder {
-  async init(options?: { jsUrl?: string; wasmUrl?: string }) {
+export class BrowserBasisEncoder {
+  private modulePromise: Promise<IBasisModule> | null = null;
+  private loadedWasmUrl: string | null = null;
+
+  init(options?: { jsUrl?: string; wasmUrl?: string }): Promise<IBasisModule> {
     if (options?.jsUrl) {
       console.warn("The jsUrl option is deprecated and ignored. The bundled Basis encoder module is always used.");
     }
-    if (!promise) {
+    const requestedWasmUrl = options?.wasmUrl ?? DEFAULT_WASM_URL;
+    if (this.modulePromise && requestedWasmUrl !== this.loadedWasmUrl) {
+      console.warn(
+        `[ktx2-encoder] init() is already using ${this.loadedWasmUrl}; ignoring different wasmUrl ${requestedWasmUrl}. ` +
+          "Create a new BrowserBasisEncoder instance to use another URL."
+      );
+    }
+    if (!this.modulePromise) {
       async function initModule(): Promise<IBasisModule> {
-        const wasmUrl = options?.wasmUrl ?? DEFAULT_WASM_URL;
-        const wasmBinary = await fetchWasmBinary(wasmUrl, options?.wasmUrl ? undefined : FALLBACK_WASM_URL);
+        const wasmBinary = await fetchWasmBinary(requestedWasmUrl, options?.wasmUrl ? undefined : FALLBACK_WASM_URL);
         const module: IBasisModule = await BASIS({ wasmBinary });
         module.initializeBasis();
         return module;
       }
-      promise = initModule();
+      this.loadedWasmUrl = requestedWasmUrl;
+      const modulePromise = initModule().catch((error) => {
+        if (this.modulePromise === modulePromise) {
+          this.modulePromise = null;
+          this.loadedWasmUrl = null;
+        }
+        throw error;
+      });
+      this.modulePromise = modulePromise;
     }
-    return promise;
+    return this.modulePromise;
   }
 
   /**

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -4,8 +4,12 @@ import { decodeImageBitmap } from "./decodeImageData.js";
 
 export * from "../enum.js";
 export * from "../type.js";
+export { BrowserBasisEncoder } from "./BrowserBasisEncoder.js";
 
-export function encodeToKTX2(imageBuffer: Uint8Array | CubeBufferData, options: IEncodeOptions): Promise<Uint8Array> {
+export function encodeToKTX2(
+  imageBuffer: Uint8Array | CubeBufferData,
+  options: Partial<IEncodeOptions> = {}
+): Promise<Uint8Array> {
   options.imageDecoder ??= decodeImageBitmap;
   globalThis.__KTX2_DEBUG__ = options.enableDebug ?? false;
   return browserEncoder.encode(imageBuffer, options);

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { read } from "ktx-parse";
 import { CubeBufferData, encodeToKTX2 } from "../src/web";
-import { browserEncoder, fetchWasmBinary } from "../src/web/BrowserBasisEncoder";
+import { BrowserBasisEncoder, browserEncoder, fetchWasmBinary } from "../src/web/BrowserBasisEncoder";
 
 test("uastc", async () => {
   const buffer = await fetch("/tests/DuckCM.png").then((res) => res.arrayBuffer());
@@ -47,6 +47,31 @@ test("falls back to the CDN when the bundled WASM cannot be loaded", async () =>
   }
 });
 
+test("retries module initialization after a failure", async () => {
+  const encoder = new BrowserBasisEncoder();
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Temporary network failure"));
+
+  await expect(encoder.init({ wasmUrl: "/basis_encoder.wasm" })).rejects.toThrow("Temporary network failure");
+  fetchMock.mockRestore();
+  await expect(encoder.init({ wasmUrl: "/basis_encoder.wasm" })).resolves.toBeDefined();
+});
+
+test("warns and reuses the module when wasmUrl changes", async () => {
+  const encoder = new BrowserBasisEncoder();
+  const firstModule = await encoder.init({ wasmUrl: "/basis_encoder.wasm" });
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  try {
+    const secondModule = await encoder.init({ wasmUrl: "/another-basis-encoder.wasm" });
+    expect(secondModule).toBe(firstModule);
+    expect(warn).toHaveBeenCalledWith(
+      "[ktx2-encoder] init() is already using /basis_encoder.wasm; ignoring different wasmUrl " +
+        "/another-basis-encoder.wasm. Create a new BrowserBasisEncoder instance to use another URL."
+    );
+  } finally {
+    warn.mockRestore();
+  }
+});
+
 test("kvData", async () => {
   const buffer = await fetch("/tests/DuckCM.png").then((res) => res.arrayBuffer());
   const result = await encodeToKTX2(new Uint8Array(buffer), {
@@ -54,7 +79,8 @@ test("kvData", async () => {
     enableDebug: false,
     qualityLevel: 230,
     generateMipmap: true,
-    kvData: { testKey: "testValue" }
+    kvData: { testKey: "testValue" },
+    wasmUrl: "/basis_encoder.wasm"
   });
 
   expect(result.buffer.byteLength).toBe(result.byteLength);
@@ -67,7 +93,8 @@ test("etc1s", async () => {
     isUASTC: false,
     enableDebug: false,
     qualityLevel: 230,
-    generateMipmap: true
+    generateMipmap: true,
+    wasmUrl: "/basis_encoder.wasm"
   });
 
   const resultBuffer = await fetch("/tests/DuckCM-etc1s.ktx2").then((res) => res.arrayBuffer());
@@ -95,7 +122,8 @@ test("textureCube", async () => {
       isUASTC: false,
       enableDebug: false,
       qualityLevel: 230,
-      generateMipmap: false
+      generateMipmap: false,
+      wasmUrl: "/basis_encoder.wasm"
     });
     // TODO: check the result
     expect(result).toBeDefined();


### PR DESCRIPTION
## Summary

- move Browser and Node module-promise state from module-level closures onto encoder instances
- clear failed browser initialization state so a later call can retry
- warn when an initialized or initializing browser encoder receives a different `wasmUrl`
- publicly export `BrowserBasisEncoder` and `NodeBasisEncoder` for callers needing isolated module instances
- align the Web `encodeToKTX2` options signature with its existing optional/partial runtime behavior

## Why

The module-level browser promise permanently captured the first call's loading options. Later URLs were silently ignored, and one transient fetch or WASM initialization failure poisoned the singleton for the rest of the page lifetime. Keeping the state on each encoder instance makes ownership explicit and allows clean independent instances.

## Impact

The existing singleton API remains unchanged. Failed browser initialization can now be retried without reloading the page. Conflicting URLs are visible through a warning and continue to reuse the already selected module; callers that truly need another URL can construct a new exported encoder instance.

## Validation

- formatting and type-aware lint checks
- `pnpm run build`
- `pnpm run test` (Node 6/6, Web 8/8)
- `pnpm run test:gltf` (Node 2/2, Web 2/2)
- real browser WASM initialization test: injected network failure followed by successful retry on the same instance
- real browser module test: second URL warns and returns the first module
