### PR TITLE
Fix VitePress docs build target

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -40,6 +40,9 @@ export default defineConfig({
   },
   // native ui
   vite: {
+    build: {
+      target: "esnext"
+    },
     ssr: {
       noExternal: ["naive-ui", "date-fns", "vueuc"]
     }


### PR DESCRIPTION
## Summary

- Set the VitePress client build target to `esnext`.
- Allows the docs build to bundle the existing Emscripten-generated Basis encoder module, which contains top-level `await` for its Node/browser compatibility shim.

## Root Cause

The Pages deployment failed during `pnpm docs:build` because VitePress inherited a lower browser target set that includes `es2020`, `chrome87`, and `safari14`. The website tools import `../../../src/web`, which pulls in `src/basis/basis_encoder.js`; that generated file contains top-level `await import("module")`. Esbuild refuses to transpile that syntax for the default VitePress target.

## Validation

- `pnpm docs:build` passes locally.
- `pnpm format:check` could not run in this checkout because `oxfmt` is missing from the local executable path (`sh: oxfmt: command not found`).